### PR TITLE
list_jobs -- return hashref

### DIFF
--- a/lib/Minion/Backend/Pg91.pm
+++ b/lib/Minion/Backend/Pg91.pm
@@ -80,12 +80,12 @@ sub job_info {
 sub list_jobs {
   my ($self, $offset, $limit, $options) = @_;
 
-  return $self->pg->db->query(
+  return { jobs => $self->pg->db->query(
     'select id from minion_jobs
      where (state = $1 or $1 is null) and (task = $2 or $2 is null)
      order by id desc
      limit $3 offset $4', @$options{qw(state task)}, $limit, $offset
-  )->arrays->map(sub { $self->job_info($_->[0]) })->to_array;
+  )->arrays->map(sub { $self->job_info($_->[0]) })->to_array};
 }
 
 sub list_workers {


### PR DESCRIPTION
Minion now seems to require a hashref from list_jobs.  This simple patch updates this module to work with Minion 8.12